### PR TITLE
Add WASM example

### DIFF
--- a/examples/110-wasm/.gitignore
+++ b/examples/110-wasm/.gitignore
@@ -1,0 +1,8 @@
+pkg
+target
+www/node_modules
+www/.bin
+www/.cache
+www/dist
+Cargo.lock
+www/package-lock.json

--- a/examples/110-wasm/.vscode/settings.json
+++ b/examples/110-wasm/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.diagnostics.disabled": [
+        "missing-unsafe"
+    ]
+}

--- a/examples/110-wasm/Cargo.toml
+++ b/examples/110-wasm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wasm_examples"
+version = "0.1.0"
+authors = ["Rainer <rainer@software-architects.at>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+console_error_panic_hook = "0.1"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/examples/110-wasm/Cargo.toml
+++ b/examples/110-wasm/Cargo.toml
@@ -8,8 +8,11 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wasm-bindgen = "0.2"
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 console_error_panic_hook = "0.1"
+serde = { version = "1.0", features = ["derive"] }
+js-sys = "0.3"
+serde-wasm-bindgen = "0.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/examples/110-wasm/Cargo.toml
+++ b/examples/110-wasm/Cargo.toml
@@ -4,10 +4,16 @@ version = "0.1.0"
 authors = ["Rainer <rainer@software-architects.at>"]
 edition = "2018"
 
+# Crate types cdylib and rlib are important.
+# cdylib is for creating a .wasm file. rlib is important for testing with "wasm-pack test".
+# Read more at https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/template-deep-dive/cargo-toml.html#1-crate-type
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+# wasm-bindgen is the most important dependency. Read more at
+# https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/template-deep-dive/cargo-toml.html#2-wasm-bindgen-dependency.
+# "serde-serialize" is important for working with JsValue.
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 console_error_panic_hook = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/110-wasm/Cargo.toml
+++ b/examples/110-wasm/Cargo.toml
@@ -19,6 +19,17 @@ console_error_panic_hook = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 js-sys = "0.3"
 serde-wasm-bindgen = "0.3"
+web-sys = { version = "0.3", features = [
+    'Document',  
+    'Element',  
+    'HtmlElement',  
+    'Node',  
+    'Window', 
+    'HtmlButtonElement', 
+    'HtmlInputElement', 
+    'HtmlUListElement', 
+    'HtmlLiElement',
+] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/examples/110-wasm/readme.md
+++ b/examples/110-wasm/readme.md
@@ -1,0 +1,22 @@
+# Rust WASM Sample
+
+## Important Links
+
+* Interesting blob posts
+  * Lin Clark: [Making WebAssembly better for Rust & for all languages](https://hacks.mozilla.org/2018/03/making-webassembly-better-for-rust-for-all-languages/) (March 2018)
+  * Alex Crichton: [JavaScript to Rust and Back Again: A *wasm-bindgen* Tale](https://hacks.mozilla.org/2018/04/javascript-to-rust-and-back-again-a-wasm-bindgen-tale/) (April 2018)
+  * Ashley Williams: [Hello *wasm-pack*!](https://hacks.mozilla.org/2018/04/hello-wasm-pack/) (April 2018)
+  * Lin Clark: [Calls between JavaScript and WebAssembly are finally fast 🎉](https://hacks.mozilla.org/2018/10/calls-between-javascript-and-webassembly-are-finally-fast-%f0%9f%8e%89/) (October 2018)
+* Documentation
+  * [The *wasm-bindgen* Guide](https://rustwasm.github.io/docs/wasm-bindgen/introduction.html)
+  * [Hello *wasm-pack*!](https://rustwasm.github.io/docs/wasm-pack/)
+* Crates
+  * [*wasm-bindgen*](https://crates.io/crates/wasm-bindgen)
+  * [*wasm-bindgen-test*](https://crates.io/crates/wasm-bindgen-test)
+  * [*js-sys*](https://crates.io/crates/js-sys)
+  * [*serde-wasm-bindgen*](https://crates.io/crates/serde-wasm-bindgen)
+  * [*web_sys*](https://crates.io/crates/web_sys)
+
+## Storyboard
+
+WIP

--- a/examples/110-wasm/readme.md
+++ b/examples/110-wasm/readme.md
@@ -1,4 +1,4 @@
-# Rust WASM Sample
+# Rust Wasm Sample
 
 ## Important Links
 
@@ -19,4 +19,14 @@
 
 ## Storyboard
 
-WIP
+We will follow the [*Getting Started* guide in the Rust Wasm book](https://rustwasm.github.io/docs/book/game-of-life/hello-world.html) to create our new package. Run `cargo generate --git https://github.com/rustwasm/wasm-pack-template` and use *wasm_examples* as your project name.
+
+If you want, you can delete files that are not relevant for learning Rust (e.g. readme-files, license-files, etc.).
+
+Use [*wasm-pack*](https://rustwasm.github.io/wasm-pack/book/) to build the code: `wasm-pack build`
+
+Use `wasm-pack test --chrome` to verify that all tests pass.
+
+Discuss the anatomy of the generated project. After this, copy the sample code from this folder into your project.
+
+The sample code in [*lib.rs*](src/lib.rs) and [*index.ts*](www/src/index.ts) demonstrates various aspects of Rust Wasm. Do a code walkthrough region-by-region. In longer workshops and trainings you can also write the code region-by-region and discuss it in details.

--- a/examples/110-wasm/src/lib.rs
+++ b/examples/110-wasm/src/lib.rs
@@ -8,12 +8,12 @@ use wasm_bindgen::JsCast;
 pub fn run() {
     // Enable forwarding panic messages to console.error. Read more about this function at
     // https://github.com/rustwasm/console_error_panic_hook. 
-    // If you want to really optimize your WASM size to the very last bit, avoid
+    // If you want to really optimize your Wasm size to the very last bit, avoid
     // panicing (read more e.g. at https://rustwasm.github.io/book/reference/code-size.html#avoid-panicking).
     console_error_panic_hook::set_once();
 
     // Use console.log to display a status message. Note: UTF8 works 👍
-    log("🦀 Rust WASM initialized 🤘".to_string());
+    log("🦀 Rust Wasm initialized 🤘".to_string());
 }
 // endregion: Initializing
 
@@ -55,7 +55,7 @@ pub fn say_hello_with_my_alert() {
 // region: Handle parameters
 // ===================================================================================================
 // Demonstrates how to handle numbers in parameters and return values.
-// Note WASM-supported data types (https://webassembly.github.io/spec/core/appendix/index-types.html).
+// Note Wasm-supported data types (https://webassembly.github.io/spec/core/appendix/index-types.html).
 // Read more about number handling at
 // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/numbers.html.
 

--- a/examples/110-wasm/src/lib.rs
+++ b/examples/110-wasm/src/lib.rs
@@ -1,0 +1,51 @@
+use wasm_bindgen::prelude::*;
+
+// ===================================================================================================
+// Demonstrates how to import functions from JS. Read more at 
+// https://rustwasm.github.io/docs/wasm-bindgen/examples/import-js.html.
+// You can read about all possible configuration options for importing JavaScript functions at 
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/attributes/on-js-imports/index.html.
+// Note that you could deploy JS code alongside your Rust code (referenced .js files
+// or inline JavaScript). Read more about this functionality at
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/js-snippets.html
+#[wasm_bindgen]
+extern "C" {
+    fn alert(s: &str);      // Import built-in alert function
+    fn myAlert(s: &str);    // Import global custom function
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);        // Import console.log function
+}
+
+// ===================================================================================================
+// Demonstrates how to export functions from Rust.  You can read about all possible
+// configuration options for exporting Rust functions at 
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/attributes/on-rust-exports/index.html.
+#[wasm_bindgen(js_name = sayHello)]
+pub fn say_hello() {
+    alert("Hello World!");
+}
+
+#[wasm_bindgen(js_name = sayHelloWithMyAlert)]
+pub fn say_hello_with_my_alert() {
+    myAlert("Hello World!");
+}
+
+// ===================================================================================================
+// Demonstrates how to handle numbers in parameters and return values.
+// Note WASM-supported data types (https://webassembly.github.io/spec/core/appendix/index-types.html).
+// Read more about number handling at
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/types/numbers.html.
+#[wasm_bindgen(js_name = workWithNumbers)]
+pub fn work_with_numbers(x: f64, y: Option<f32>, r: i32) -> i64 {
+    x as i64 + match y { Some(vy) => vy as i64, _ => 0i64 } + r as i64
+}
+
+#[wasm_bindgen]
+pub fn run() {
+    // Enable forwarding panic messages to console.error. Read more about this function at
+    // https://github.com/rustwasm/console_error_panic_hook
+    console_error_panic_hook::set_once();
+
+    // Use console.log to display a status message. Note: UTF8 works 👍
+    log("🦀 Rust WASM initialized 🤘")
+}

--- a/examples/110-wasm/src/lib.rs
+++ b/examples/110-wasm/src/lib.rs
@@ -1,4 +1,5 @@
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{prelude::*};
+use serde::{Serialize, Deserialize};
 
 // ===================================================================================================
 // Demonstrates how to import functions from JS. Read more at 
@@ -20,11 +21,14 @@ extern "C" {
 // Demonstrates how to export functions from Rust.  You can read about all possible
 // configuration options for exporting Rust functions at 
 // https://rustwasm.github.io/docs/wasm-bindgen/reference/attributes/on-rust-exports/index.html.
+
+/// Says hello using JavaScript's `alert` function
 #[wasm_bindgen(js_name = sayHello)]
 pub fn say_hello() {
     alert("Hello World!");
 }
 
+/// Says hello using custom `myAlert` function
 #[wasm_bindgen(js_name = sayHelloWithMyAlert)]
 pub fn say_hello_with_my_alert() {
     myAlert("Hello World!");
@@ -35,15 +39,240 @@ pub fn say_hello_with_my_alert() {
 // Note WASM-supported data types (https://webassembly.github.io/spec/core/appendix/index-types.html).
 // Read more about number handling at
 // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/numbers.html.
+
+/// Adds three numbers
+///
+/// * `x` - A float number
+/// * `y` - An optional float number
+/// * `r` - An int number
 #[wasm_bindgen(js_name = workWithNumbers)]
 pub fn work_with_numbers(x: f64, y: Option<f32>, r: i32) -> i64 {
     x as i64 + match y { Some(vy) => vy as i64, _ => 0i64 } + r as i64
 }
 
+// ===================================================================================================
+// Demonstrates how to handle booleans and variadics in parameters and return values.
+// Read more about bool handling at
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/types/bool.html.
+
+/// Checks whether all parameters are true
+#[wasm_bindgen(js_name = allTrue)]
+pub fn all_true(a: bool, another: bool) -> bool {
+    a && another
+}
+
+// ===================================================================================================
+// Demonstrates the consequences of using console_error_panic_hook
+
+/// Will panic
+#[wasm_bindgen]
+#[allow(unconditional_panic)]
+pub fn panic() -> i32 {
+    let x = 42;
+    let y = 0;
+    x / y
+}
+
+// ===================================================================================================
+// Demonstrates how to work with number slices. Read more about number slices at
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/types/number-slices.html and
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/types/boxed-number-slices.html.
+
+/// Fills given number slice with fibonacci numbers
+#[wasm_bindgen(js_name = fillWithFibonacci)]
+pub fn fill_with_fibonacci(buffer: &mut [i32]) {
+    if buffer.len() == 0 { return; }
+    buffer[0] = 0;
+
+    if buffer.len() == 1 { return; }
+    buffer[1] = 1;
+
+    for i in 2..buffer.len() {
+        buffer[i] = buffer[i - 1] + buffer[ i - 2];
+    }
+}
+
+// ===================================================================================================
+// Demonstrates how to work with strings. Read more about handling strings at
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/types/str.html,
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/types/string.html, and
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/types/char.html.
+
+/// Prints the given message to console and returns the message unchanged.
+#[wasm_bindgen(js_name = writeToConsole)]
+pub fn write_to_console(msg: &str) -> String {
+    log(msg);
+    msg.to_string()
+}
+
+// ===================================================================================================
+// Demonstrates how to work with exported types. Check the generated .d.ts file for the related
+// TypeScript type definitions. For more information about Rust-exported types see
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/types/exported-rust-types.html.
+// Note that we need to implement a static constructor function. The `new` keyword
+// cannot be used in JS in conjunction with `Person`. Also note that String props 
+// cannot be made public because of the missing Copy trait. We need to explicitly provide getters.
+
+/// Represents a person
+#[wasm_bindgen]
+pub struct Person {
+    first_name: String,
+    last_name: String,
+    pub age: f64,
+}
+
+#[wasm_bindgen]
+impl Person {
+    /// Constructs a new person.
+    #[wasm_bindgen]
+    pub fn new(first_name: String, last_name: String, age: f64) -> Person {
+        Person { first_name, last_name, age}
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn first_name(&self) -> String {
+        self.first_name.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn last_name(&self) -> String {
+        self.last_name.clone()
+    }
+}
+
+// For demo purposes, we implement the Drop trait manually. This can be used to find out
+// if instances are dropped properly.
+impl Drop for Person {
+    fn drop(&mut self) {
+        log(format!("Dropping {}", self.first_name).as_str());
+    }
+}
+
+/// Adds given change to a person's age and returns the changed person.
+#[wasm_bindgen(js_name = "fixAge")]
+pub fn fix_age(person: Person, age_change: f64) -> Person {
+    // Note: If you would change person to &Person instead of Person, the function
+    // would no longer take ownership and the person would not be dropped automatically. If we take
+    // a borrowed reference, JS is responsible to explicitly call `free`.
+    Person { first_name: "Rust".to_string(), last_name: person.last_name.clone(), age: person.age + age_change }
+}
+
+// ===================================================================================================
+// Demonstrates how to work with JsValue type. For more information see
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/types/jsvalue.html.
+
+#[derive(Serialize, Deserialize)]
+struct PersonDynamic {
+    #[serde(rename = "firstName")]
+    first_name: String,
+    #[serde(rename = "lastName")]
+    last_name: String,
+    age: f64,
+}
+
+// Turns any given std::error::Error into a JS error message
+fn into_js_error(err: impl std::error::Error) -> JsValue {
+    // Note that we could just return err.to_string().into().
+    // However, in that case we would not get the stack trace.
+    js_sys::Error::new(&err.to_string()).into()
+}
+
+// Note that the use of JsValue results in `any` in TypeScript.
+#[wasm_bindgen(js_name = "fixAgeDynamic")]
+pub fn fix_age_dynamic(person: JsValue, age_change: JsValue) -> Result<JsValue, JsValue> {
+    // Serialize data in JS using JSON.stringify, send string to Rust, and deserialize 
+    // everything in Rust with serde. Relatively expensive, but good compatibility.
+    // Note that we return a meaningful error if deserilization does not work.
+    let mut p: PersonDynamic = person.into_serde().map_err(into_js_error)?;
+
+    // Check data type and process it if data type fits
+    if let Some(ac) = age_change.as_f64() {
+        p.age = p.age + ac;
+    }
+
+    // Serialize result in Rust, send string to JS, and deserialize everything in JS.
+    let result = JsValue::from_serde(&p).map_err(into_js_error)?;
+    Ok(result)
+}
+
+// ===================================================================================================
+// Demonstrates how to work with serde_wasm_bindgen. For more information see
+// https://crates.io/crates/serde-wasm-bindgen. The big difference compared to the 
+// sample above is that data is not serialized/deserialized via JSON. The crate
+// uses direct APIs for JavaScript value manipulation instead.
+
+#[wasm_bindgen(js_name = "fixAgeSerdeWasm")]
+pub fn fix_age_serde_wasm(person: JsValue, age_change: JsValue) -> Result<JsValue, JsValue> {
+    let mut p: PersonDynamic = serde_wasm_bindgen::from_value(person)?;
+    let ac: f64 = serde_wasm_bindgen::from_value(age_change)?;
+    p.age = p.age + ac;
+    Ok(serde_wasm_bindgen::to_value(&p)?)
+}
+
+// ===================================================================================================
+// Demonstrates how to work with a shared buffer between Rust and JS. For more information see
+// https://rustwasm.github.io/docs/wasm-bindgen/reference/types/pointers.html.
+// In this example we implement Knight Rider-like scanner lights.
+#[derive(PartialEq, Eq)]
+pub enum Direction {
+    Left,
+    Right,
+}
+
+#[wasm_bindgen]
+pub struct Display {
+    pixel: Vec<u8>,
+    direction: Direction,
+}
+
+/// Intensity of leading light
+const MAX_INTENSITY: u8 = 5;
+
+#[wasm_bindgen]
+impl Display {
+    /// Creates a new "display". Each display represents the light intensity of the corresponding LED.
+    pub fn new(size: usize) -> Display {
+        let mut result = Display { pixel: vec![0; size], direction: Direction::Right, };
+        result.pixel[0] = MAX_INTENSITY;
+        result
+    }
+
+    /// Gets a pointer to the shared buffer with light intensities per LED.
+    pub fn pixel(&self) -> *const u8 {
+        self.pixel.as_ptr()
+    }
+
+    /// Advance LED to next position.
+    pub fn next(&mut self) {
+        let ix = self.pixel.iter().position(|p| *p == MAX_INTENSITY).unwrap();
+        let next_ix: usize;
+        if ix == 0 {
+            // We reached left border -> turn around
+            self.direction = Direction::Right;
+        }
+        else if ix == self.pixel.len() - 1 { 
+            // We reached right border -> turn around
+            self.direction = Direction::Left;
+        }
+
+        // Calculate next index of leading light
+        next_ix = ix + match self.direction { Direction::Left => -1, Direction::Right => 1 } as usize;
+
+        // Reduce intensity of remaining lights
+        self.pixel.iter_mut().for_each(|p| if *p > 0 { *p = *p - 1; });
+
+        // Set leading light
+        self.pixel[next_ix] = MAX_INTENSITY;
+    }
+}
+
 #[wasm_bindgen]
 pub fn run() {
     // Enable forwarding panic messages to console.error. Read more about this function at
-    // https://github.com/rustwasm/console_error_panic_hook
+    // https://github.com/rustwasm/console_error_panic_hook. Try panic with and without
+    // console_error_panic_hook and see the difference in the browser's console log.
+    // If you want to really optimize your WASM size to the very last bit, avoid
+    // panicing (read more e.g. at https://rustwasm.github.io/book/reference/code-size.html#avoid-panicking).
     console_error_panic_hook::set_once();
 
     // Use console.log to display a status message. Note: UTF8 works 👍

--- a/examples/110-wasm/src/lib.rs
+++ b/examples/110-wasm/src/lib.rs
@@ -51,7 +51,7 @@ pub fn work_with_numbers(x: f64, y: Option<f32>, r: i32) -> i64 {
 }
 
 // ===================================================================================================
-// Demonstrates how to handle booleans and variadics in parameters and return values.
+// Demonstrates how to handle booleans in parameters and return values.
 // Read more about bool handling at
 // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/bool.html.
 

--- a/examples/110-wasm/src/lib.rs
+++ b/examples/110-wasm/src/lib.rs
@@ -1,6 +1,21 @@
 use wasm_bindgen::{prelude::*};
 use serde::{Serialize, Deserialize};
 
+// region: Initializing
+#[wasm_bindgen]
+pub fn run() {
+    // Enable forwarding panic messages to console.error. Read more about this function at
+    // https://github.com/rustwasm/console_error_panic_hook. 
+    // If you want to really optimize your WASM size to the very last bit, avoid
+    // panicing (read more e.g. at https://rustwasm.github.io/book/reference/code-size.html#avoid-panicking).
+    console_error_panic_hook::set_once();
+
+    // Use console.log to display a status message. Note: UTF8 works 👍
+    log("🦀 Rust WASM initialized 🤘")
+}
+// endregion: Initializing
+
+// region: Importing/exporting functions from JS/Rust
 // ===================================================================================================
 // Demonstrates how to import functions from JS. Read more at 
 // https://rustwasm.github.io/docs/wasm-bindgen/examples/import-js.html.
@@ -33,7 +48,9 @@ pub fn say_hello() {
 pub fn say_hello_with_my_alert() {
     myAlert("Hello World!");
 }
+// endregion: Importing/exporting functions from JS/Rust
 
+// region: Handle parameters
 // ===================================================================================================
 // Demonstrates how to handle numbers in parameters and return values.
 // Note WASM-supported data types (https://webassembly.github.io/spec/core/appendix/index-types.html).
@@ -60,9 +77,12 @@ pub fn work_with_numbers(x: f64, y: Option<f32>, r: i32) -> i64 {
 pub fn all_true(a: bool, another: bool) -> bool {
     a && another
 }
+// endregion: Handle parameters
 
+// region: Panic
 // ===================================================================================================
-// Demonstrates the consequences of using console_error_panic_hook
+// Demonstrates the consequences of using console_error_panic_hook.
+// Try panic with and without console_error_panic_hook and see the difference in the browser's console log.
 
 /// Will panic
 #[wasm_bindgen]
@@ -72,7 +92,9 @@ pub fn panic() -> i32 {
     let y = 0;
     x / y
 }
+// endregion: Panic
 
+// region: Number slices
 // ===================================================================================================
 // Demonstrates how to work with number slices. Read more about number slices at
 // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/number-slices.html and
@@ -91,7 +113,9 @@ pub fn fill_with_fibonacci(buffer: &mut [i32]) {
         buffer[i] = buffer[i - 1] + buffer[ i - 2];
     }
 }
+// endregion: Number slices
 
+// region: Strings
 // ===================================================================================================
 // Demonstrates how to work with strings. Read more about handling strings at
 // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/str.html,
@@ -104,7 +128,9 @@ pub fn write_to_console(msg: &str) -> String {
     log(msg);
     msg.to_string()
 }
+// endregion: Strings
 
+// region: Exported types
 // ===================================================================================================
 // Demonstrates how to work with exported types. Check the generated .d.ts file for the related
 // TypeScript type definitions. For more information about Rust-exported types see
@@ -156,7 +182,9 @@ pub fn fix_age(person: Person, age_change: f64) -> Person {
     // a borrowed reference, JS is responsible to explicitly call `free`.
     Person { first_name: "Rust".to_string(), last_name: person.last_name.clone(), age: person.age + age_change }
 }
+// endregion: Exported types
 
+// region: Working with JsValue
 // ===================================================================================================
 // Demonstrates how to work with JsValue type. For more information see
 // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/jsvalue.html.
@@ -194,7 +222,9 @@ pub fn fix_age_dynamic(person: JsValue, age_change: JsValue) -> Result<JsValue, 
     let result = JsValue::from_serde(&p).map_err(into_js_error)?;
     Ok(result)
 }
+// endregion: Working with JsValue
 
+// region: Working with serde_wasm_bindgen
 // ===================================================================================================
 // Demonstrates how to work with serde_wasm_bindgen. For more information see
 // https://crates.io/crates/serde-wasm-bindgen. The big difference compared to the 
@@ -208,7 +238,9 @@ pub fn fix_age_serde_wasm(person: JsValue, age_change: JsValue) -> Result<JsValu
     p.age = p.age + ac;
     Ok(serde_wasm_bindgen::to_value(&p)?)
 }
+// endregion: Working with serde_wasm_bindgen
 
+// region: Working with shared buffers
 // ===================================================================================================
 // Demonstrates how to work with a shared buffer between Rust and JS. For more information see
 // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/pointers.html.
@@ -265,16 +297,4 @@ impl Display {
         self.pixel[next_ix] = MAX_INTENSITY;
     }
 }
-
-#[wasm_bindgen]
-pub fn run() {
-    // Enable forwarding panic messages to console.error. Read more about this function at
-    // https://github.com/rustwasm/console_error_panic_hook. Try panic with and without
-    // console_error_panic_hook and see the difference in the browser's console log.
-    // If you want to really optimize your WASM size to the very last bit, avoid
-    // panicing (read more e.g. at https://rustwasm.github.io/book/reference/code-size.html#avoid-panicking).
-    console_error_panic_hook::set_once();
-
-    // Use console.log to display a status message. Note: UTF8 works 👍
-    log("🦀 Rust WASM initialized 🤘")
-}
+// endregion: Working with shared buffers

--- a/examples/110-wasm/tests/web.rs
+++ b/examples/110-wasm/tests/web.rs
@@ -1,0 +1,13 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn pass() {
+    assert_eq!(1 + 1, 2);
+}

--- a/examples/110-wasm/www/package.json
+++ b/examples/110-wasm/www/package.json
@@ -16,10 +16,10 @@
     "html-webpack-plugin": "^5.3.2",
     "style-loader": "^3.0.0",
     "ts-loader": "^9.2.3",
-    "typescript": "^4.3.5",
-    "webpack": "^5.44.0",
+    "typescript": "^4.4.2",
+    "webpack": "^5.51.1",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.0.0"
   },
   "dependencies": {
     "wasm_examples": "file:../pkg"

--- a/examples/110-wasm/www/package.json
+++ b/examples/110-wasm/www/package.json
@@ -22,6 +22,7 @@
     "webpack-dev-server": "^4.0.0"
   },
   "dependencies": {
+    "cash-dom": "^8.1.0",
     "wasm_examples": "file:../pkg"
   }
 }

--- a/examples/110-wasm/www/package.json
+++ b/examples/110-wasm/www/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "wasm-examples",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "webpack --config webpack.config.js",
+    "start": "webpack serve"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "base64-loader": "^1.0.0",
+    "css-loader": "^6.2.0",
+    "hello-wasm-pack": "^0.1.0",
+    "html-webpack-plugin": "^5.3.2",
+    "style-loader": "^3.0.0",
+    "ts-loader": "^9.2.3",
+    "typescript": "^4.3.5",
+    "webpack": "^5.44.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
+  },
+  "dependencies": {
+    "wasm_examples": "file:../pkg"
+  }
+}

--- a/examples/110-wasm/www/src/bootstrap.ts
+++ b/examples/110-wasm/www/src/bootstrap.ts
@@ -1,0 +1,5 @@
+// A dependency graph that contains any wasm must all be imported
+// asynchronously. This `bootstrap.js` file does the single async import, so
+// that no one else needs to worry about it again.
+import("./index")
+  .catch(e => console.error("Error importing `index.js`:", e));

--- a/examples/110-wasm/www/src/index.css
+++ b/examples/110-wasm/www/src/index.css
@@ -1,0 +1,22 @@
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+h1 {
+    font-size: 20px;
+}
+
+h2 {
+    font-size: 14px;
+    margin-top: 20px;
+    margin-bottom: 0;
+}
+
+p {
+    font-size: 12px;
+}
+
+canvas {
+    border: 1px solid black;
+    padding: 1px;
+}

--- a/examples/110-wasm/www/src/index.html
+++ b/examples/110-wasm/www/src/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WASM Examples</title>
+    <title>Wasm Examples</title>
 </head>
 <body>
-    <h1>WASM Examples</h1>
+    <h1>Wasm Examples</h1>
     
     <p>
         Most demos write output to console. Please open developer tools and
@@ -37,7 +37,7 @@
     <h2>Communicating With Custom Types</h2>
     <button id="exportedType">Exported Type 📢</button>
     <button id="jsValue">With JsValue 📞</button>
-    <button id="serdeWasm">With Serde WASM Bindgen 😅</button>
+    <button id="serdeWasm">With Serde Wasm Bindgen 😅</button>
 
     <h2>Pointers To Shared Buffers</h2>
     <canvas id="canvas" width="300" height="10"></canvas>

--- a/examples/110-wasm/www/src/index.html
+++ b/examples/110-wasm/www/src/index.html
@@ -41,5 +41,9 @@
 
     <h2>Pointers To Shared Buffers</h2>
     <canvas id="canvas" width="300" height="10"></canvas>
+
+    <h2>DOM Manipulation With web_sys</h2>
+    <input id="newTodoItem" type="text"/><button id="addTodoItem">Add ➕</button>
+    <ul id="todoItems"></ul>
 </body>
 </html>

--- a/examples/110-wasm/www/src/index.html
+++ b/examples/110-wasm/www/src/index.html
@@ -9,9 +9,23 @@
 <body>
     <h1>WASM Examples</h1>
     
-    <button id="sayHello">Say hello</button>
-    <button id="sayHelloWithMyAlert">Say hello with my alert</button>
+    <button id="sayHello">Say hello 👋</button>
+    <button id="sayHelloWithMyAlert">Say hello with my alert 🔔</button>
     <br/>
-    <button id="workWithNumbers">Work with numbers</button>
+    <button id="workWithNumbers">Work with numbers 🔢</button>
+    <br/>
+    <button id="panic">Panic ⚡</button>
+    <br/>
+    <button id="bools">Check if bools are true ✅</button>
+    <br/>
+    <button id="fib">Fibonacci 🔗</button><span id="fibResult"></span>
+    <br/>
+    <button id="strings">Strings 🔠</button>
+    <br/>
+    <button id="exportedType">Exported Type 📢</button>
+    <button id="jsValue">With JsValue 📞</button>
+    <button id="serdeWasm">With Serde WASM Bindgen 😅</button>
+    <br/>
+    <canvas id="canvas" width="300" height="10" style="border: 1px solid black; margin-top: 5px; padding: 1px;"></canvas>
 </body>
 </html>

--- a/examples/110-wasm/www/src/index.html
+++ b/examples/110-wasm/www/src/index.html
@@ -9,23 +9,37 @@
 <body>
     <h1>WASM Examples</h1>
     
+    <p>
+        Most demos write output to console. Please open developer tools and
+        view console output while trying examples below.
+    </p>
+
+    <h2>Calling Rust From JS And Vice Versa</h2>
     <button id="sayHello">Say hello 👋</button>
     <button id="sayHelloWithMyAlert">Say hello with my alert 🔔</button>
-    <br/>
+
+    <h2>Numeric Parameters and Return Values</h2>
     <button id="workWithNumbers">Work with numbers 🔢</button>
-    <br/>
-    <button id="panic">Panic ⚡</button>
-    <br/>
+
+    <h2>Boolean parameters</h2>
     <button id="bools">Check if bools are true ✅</button>
-    <br/>
-    <button id="fib">Fibonacci 🔗</button><span id="fibResult"></span>
-    <br/>
+
+    <h2>Handling Panics</h2>
+    <button id="panic">Panic ⚡</button>
+
+    <h2>Number Slices</h2>
+    <button id="fib">Fibonacci 🔗</button><br/>
+    <span id="fibResult"></span>
+
+    <h2>String Handling</h2>
     <button id="strings">Strings 🔠</button>
-    <br/>
+
+    <h2>Communicating With Custom Types</h2>
     <button id="exportedType">Exported Type 📢</button>
     <button id="jsValue">With JsValue 📞</button>
     <button id="serdeWasm">With Serde WASM Bindgen 😅</button>
-    <br/>
-    <canvas id="canvas" width="300" height="10" style="border: 1px solid black; margin-top: 5px; padding: 1px;"></canvas>
+
+    <h2>Pointers To Shared Buffers</h2>
+    <canvas id="canvas" width="300" height="10"></canvas>
 </body>
 </html>

--- a/examples/110-wasm/www/src/index.html
+++ b/examples/110-wasm/www/src/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WASM Examples</title>
+</head>
+<body>
+    <h1>WASM Examples</h1>
+    
+    <button id="sayHello">Say hello</button>
+    <button id="sayHelloWithMyAlert">Say hello with my alert</button>
+    <br/>
+    <button id="workWithNumbers">Work with numbers</button>
+</body>
+</html>

--- a/examples/110-wasm/www/src/index.ts
+++ b/examples/110-wasm/www/src/index.ts
@@ -1,0 +1,19 @@
+import * as we from 'wasm_examples';
+
+we.run();
+
+const sayHelloBtn = document.getElementById('sayHello') as HTMLButtonElement;
+const sayHelloWithMyAlertBtn = document.getElementById('sayHelloWithMyAlert') as HTMLButtonElement;
+const workWithNumbersBtn = document.getElementById('workWithNumbers') as HTMLButtonElement;
+
+// Define a global function that will be called by Rust
+(<any>window).myAlert = (msg: string) => alert(msg);
+
+// Call functions exported from Rust
+sayHelloBtn.onclick = () => we.sayHello();
+sayHelloWithMyAlertBtn.onclick = () => we.sayHelloWithMyAlert();
+
+workWithNumbersBtn.onclick = () => {
+    console.log(`The result is ${we.workWithNumbers(0x1ffffffffffffd, 1, 1).toString(16)}`);
+    console.log(`The result is ${we.workWithNumbers(0x1ffffffffffffe, undefined, 1).toString(16)}`);
+};

--- a/examples/110-wasm/www/src/index.ts
+++ b/examples/110-wasm/www/src/index.ts
@@ -137,4 +137,7 @@ $(() => {
         display.next();
     }, 50);
     //#endregion
+
+    // Setup todo maintenance (done 100% in Rust)
+    we.setup_todo();
 });

--- a/examples/110-wasm/www/src/index.ts
+++ b/examples/110-wasm/www/src/index.ts
@@ -5,7 +5,7 @@ import { memory } from 'wasm_examples/wasm_examples_bg.wasm';
 import $ from 'cash-dom';
 
 $(() => {
-    // Initialize our WASM package
+    // Initialize our Wasm package
     we.run();
 
     //#region Importing/exporting functions from JS/Rust
@@ -74,7 +74,7 @@ $(() => {
         let person: we.Person, p: we.Person;
         try {
             // Create person using constructor function.
-            // Note that person lives in "WASM land".
+            // Note that person lives in "Wasm land".
             person = we.Person.new('JS', 'Foo', 42);
 
             // Call method. Method takes ownership of person and will

--- a/examples/110-wasm/www/src/index.ts
+++ b/examples/110-wasm/www/src/index.ts
@@ -1,10 +1,20 @@
 import * as we from 'wasm_examples';
+import { memory } from 'wasm_examples/wasm_examples_bg.wasm';
 
 we.run();
 
 const sayHelloBtn = document.getElementById('sayHello') as HTMLButtonElement;
 const sayHelloWithMyAlertBtn = document.getElementById('sayHelloWithMyAlert') as HTMLButtonElement;
 const workWithNumbersBtn = document.getElementById('workWithNumbers') as HTMLButtonElement;
+const panicBtn = document.getElementById('panic') as HTMLButtonElement;
+const boolsBtn = document.getElementById('bools') as HTMLButtonElement;
+const fibBtn = document.getElementById('fib') as HTMLButtonElement;
+const fibResult = document.getElementById('fibResult') as HTMLSpanElement;
+const stringsBtn = document.getElementById('strings') as HTMLButtonElement;
+const exportedTypeBtn = document.getElementById('exportedType') as HTMLButtonElement;
+const jsValueBtn = document.getElementById('jsValue') as HTMLButtonElement;
+const serdeWasmBtn = document.getElementById('serdeWasm') as HTMLButtonElement;
+const canvas = document.getElementById('canvas') as HTMLCanvasElement;
 
 // Define a global function that will be called by Rust
 (<any>window).myAlert = (msg: string) => alert(msg);
@@ -13,7 +23,106 @@ const workWithNumbersBtn = document.getElementById('workWithNumbers') as HTMLBut
 sayHelloBtn.onclick = () => we.sayHello();
 sayHelloWithMyAlertBtn.onclick = () => we.sayHelloWithMyAlert();
 
+// Demonstrate working with numbers
 workWithNumbersBtn.onclick = () => {
     console.log(`The result is ${we.workWithNumbers(0x1ffffffffffffd, 1, 1).toString(16)}`);
     console.log(`The result is ${we.workWithNumbers(0x1ffffffffffffe, undefined, 1).toString(16)}`);
 };
+
+panicBtn.onclick = () => {
+    try {
+        we.panic();
+    } catch (ex) {
+        console.error(ex);
+    }
+};
+
+boolsBtn.onclick = () => alert((we.allTrue(true, true) ? "" : "NOT ") + "all are true");
+
+fibBtn.onclick = () => {
+    const buffer = new Int32Array(10);
+    we.fillWithFibonacci(buffer);
+    fibResult.innerText = buffer.join(',');
+}
+
+stringsBtn.onclick = () => {
+    // Note that the following text contains a paired surrogate char (\ud834\udd1e = 𝄞).
+    // It also contains an unpaired surrogate char (\ud834). This is fine in JavaScript.
+    // If you pass it to Rust, Rust will replace the unpaired surrogate with \ufffd (�).
+    let text = "ABCabc🎵\ud834\udd1e\ud834";
+
+    // Print the text to console and pass-through the text from Rust back to JS.
+    // Passing through the text will "destroy" the unpaired surrogate.
+    let newText = we.writeToConsole("Original: " + text);
+
+    // It is fine to "fix" the unpaired surrogate based on the JS string.
+    // Fixing it based on the Rust string will not work because unpaired surrogate
+    // will have been "destroyed".
+    text += "\udd1e";
+    newText += "\udd1e";
+    we.writeToConsole("Fixed (JS): " + text);
+    we.writeToConsole("\"Fixed\" (Rust): " + newText);
+
+    // For more information about handling of unpaired surrogates read
+    // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/str.html#utf-16-vs-utf-8
+}
+
+exportedTypeBtn.onclick = () => {
+    let person: we.Person, p: we.Person;
+    try {
+        // Create person using constructor function.
+        // Note that person lives in "WASM land".
+        person = we.Person.new('JS', 'Foo', 42);
+
+        // Call method. Method takes ownership of person and will
+        // therefore free the associated memory.
+        p = we.fixAge(person, 2);
+        console.log(`${p.first_name}, ${p.last_name}, ${p.age}`);
+    } catch (ex) {
+        console.error(ex);
+    } finally {
+        // Free person returned by fixAge.
+        if (p) p.free();
+    }
+}
+
+jsValueBtn.onclick = () => {
+    try {
+        // Tip: Try to mess up person object and see error handling in action
+        const p = we.fixAgeDynamic({ firstName: 'Foo', lastName: 'Bar', age: 42}, 2);
+        console.log(p);
+    } catch (ex) {
+        console.error(ex);
+    }
+}
+
+serdeWasmBtn.onclick = () => {
+    try {
+        // Tip: Try to mess up person object and see error handling in action
+        const p = we.fixAgeSerdeWasm({ firstName: 'Foo', lastName: 'Bar', age: 42}, 2);
+        console.log(p);
+    } catch (ex) {
+        console.error(ex);
+    }
+}
+
+// Create a new display object
+const display = we.Display.new(30);
+
+// Get shared buffer and access it via Uint8Array
+const pixel =  new Uint8Array(memory.buffer, display.pixel(), 30);
+
+// Regularly redraw canvas
+const ctx = canvas.getContext('2d', { alpha: false });
+setInterval(() => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (let i = 0; i < pixel.length; i++) {
+        if (pixel[i] > 0) {
+            // Intensity of RED depends on value in shared buffer
+            ctx.fillStyle = `hsl(0, 100%, ${100 - 10 * pixel[i]}%)`;
+            ctx.fillRect(i * 10, 0, 10, 10);
+        }
+    }
+
+    display.next();
+}, 50);

--- a/examples/110-wasm/www/src/index.ts
+++ b/examples/110-wasm/www/src/index.ts
@@ -1,128 +1,122 @@
+import './index.css';
+
 import * as we from 'wasm_examples';
 import { memory } from 'wasm_examples/wasm_examples_bg.wasm';
+import $ from 'cash-dom';
 
-we.run();
+$(() => {
+    // Initialize our WASM package
+    we.run();
 
-const sayHelloBtn = document.getElementById('sayHello') as HTMLButtonElement;
-const sayHelloWithMyAlertBtn = document.getElementById('sayHelloWithMyAlert') as HTMLButtonElement;
-const workWithNumbersBtn = document.getElementById('workWithNumbers') as HTMLButtonElement;
-const panicBtn = document.getElementById('panic') as HTMLButtonElement;
-const boolsBtn = document.getElementById('bools') as HTMLButtonElement;
-const fibBtn = document.getElementById('fib') as HTMLButtonElement;
-const fibResult = document.getElementById('fibResult') as HTMLSpanElement;
-const stringsBtn = document.getElementById('strings') as HTMLButtonElement;
-const exportedTypeBtn = document.getElementById('exportedType') as HTMLButtonElement;
-const jsValueBtn = document.getElementById('jsValue') as HTMLButtonElement;
-const serdeWasmBtn = document.getElementById('serdeWasm') as HTMLButtonElement;
-const canvas = document.getElementById('canvas') as HTMLCanvasElement;
+    // Call functions exported from Rust
+    $('#sayHello').on('click', () => we.sayHello());
+    
+    // Define a global function that will be called by Rust
+    (<any>window).myAlert = (msg: string) => alert(msg);
+    $('#sayHelloWithMyAlert').on('click', () => we.sayHelloWithMyAlert());
 
-// Define a global function that will be called by Rust
-(<any>window).myAlert = (msg: string) => alert(msg);
+    // Demonstrate working with numbers
+    $('#workWithNumbers').on('click', () => {
+        console.log(`The result is ${we.workWithNumbers(0x1ffffffffffffd, 1, 1).toString(16)}`);
+        console.log(`The result is ${we.workWithNumbers(0x1ffffffffffffe, undefined, 1).toString(16)}`);
+    });
 
-// Call functions exported from Rust
-sayHelloBtn.onclick = () => we.sayHello();
-sayHelloWithMyAlertBtn.onclick = () => we.sayHelloWithMyAlert();
+    $('#bools').on('click', () => alert((we.allTrue(true, true) ? "" : "NOT ") + "all are true"));
 
-// Demonstrate working with numbers
-workWithNumbersBtn.onclick = () => {
-    console.log(`The result is ${we.workWithNumbers(0x1ffffffffffffd, 1, 1).toString(16)}`);
-    console.log(`The result is ${we.workWithNumbers(0x1ffffffffffffe, undefined, 1).toString(16)}`);
-};
-
-panicBtn.onclick = () => {
-    try {
-        we.panic();
-    } catch (ex) {
-        console.error(ex);
-    }
-};
-
-boolsBtn.onclick = () => alert((we.allTrue(true, true) ? "" : "NOT ") + "all are true");
-
-fibBtn.onclick = () => {
-    const buffer = new Int32Array(10);
-    we.fillWithFibonacci(buffer);
-    fibResult.innerText = buffer.join(',');
-}
-
-stringsBtn.onclick = () => {
-    // Note that the following text contains a paired surrogate char (\ud834\udd1e = 𝄞).
-    // It also contains an unpaired surrogate char (\ud834). This is fine in JavaScript.
-    // If you pass it to Rust, Rust will replace the unpaired surrogate with \ufffd (�).
-    let text = "ABCabc🎵\ud834\udd1e\ud834";
-
-    // Print the text to console and pass-through the text from Rust back to JS.
-    // Passing through the text will "destroy" the unpaired surrogate.
-    let newText = we.writeToConsole("Original: " + text);
-
-    // It is fine to "fix" the unpaired surrogate based on the JS string.
-    // Fixing it based on the Rust string will not work because unpaired surrogate
-    // will have been "destroyed".
-    text += "\udd1e";
-    newText += "\udd1e";
-    we.writeToConsole("Fixed (JS): " + text);
-    we.writeToConsole("\"Fixed\" (Rust): " + newText);
-
-    // For more information about handling of unpaired surrogates read
-    // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/str.html#utf-16-vs-utf-8
-}
-
-exportedTypeBtn.onclick = () => {
-    let person: we.Person, p: we.Person;
-    try {
-        // Create person using constructor function.
-        // Note that person lives in "WASM land".
-        person = we.Person.new('JS', 'Foo', 42);
-
-        // Call method. Method takes ownership of person and will
-        // therefore free the associated memory.
-        p = we.fixAge(person, 2);
-        console.log(`${p.first_name}, ${p.last_name}, ${p.age}`);
-    } catch (ex) {
-        console.error(ex);
-    } finally {
-        // Free person returned by fixAge.
-        if (p) p.free();
-    }
-}
-
-jsValueBtn.onclick = () => {
-    try {
-        // Tip: Try to mess up person object and see error handling in action
-        const p = we.fixAgeDynamic({ firstName: 'Foo', lastName: 'Bar', age: 42}, 2);
-        console.log(p);
-    } catch (ex) {
-        console.error(ex);
-    }
-}
-
-serdeWasmBtn.onclick = () => {
-    try {
-        // Tip: Try to mess up person object and see error handling in action
-        const p = we.fixAgeSerdeWasm({ firstName: 'Foo', lastName: 'Bar', age: 42}, 2);
-        console.log(p);
-    } catch (ex) {
-        console.error(ex);
-    }
-}
-
-// Create a new display object
-const display = we.Display.new(30);
-
-// Get shared buffer and access it via Uint8Array
-const pixel =  new Uint8Array(memory.buffer, display.pixel(), 30);
-
-// Regularly redraw canvas
-const ctx = canvas.getContext('2d', { alpha: false });
-setInterval(() => {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    for (let i = 0; i < pixel.length; i++) {
-        if (pixel[i] > 0) {
-            // Intensity of RED depends on value in shared buffer
-            ctx.fillStyle = `hsl(0, 100%, ${100 - 10 * pixel[i]}%)`;
-            ctx.fillRect(i * 10, 0, 10, 10);
+    $('#panic').on('click', () => {
+        try {
+            we.panic();
+        } catch (ex) {
+            console.error(ex);
         }
-    }
+    });
 
-    display.next();
-}, 50);
+    $('#fib').on('click', () => {
+        const buffer = new Int32Array(10);
+        we.fillWithFibonacci(buffer);
+        $('#fibResult').text(buffer.join(','));
+    });
+
+    $('#strings').on('click', () => {
+        // Note that the following text contains a paired surrogate char (\ud834\udd1e = 𝄞).
+        // It also contains an unpaired surrogate char (\ud834). This is fine in JavaScript.
+        // If you pass it to Rust, Rust will replace the unpaired surrogate with \ufffd (�).
+        let text = "ABCabc🎵\ud834\udd1e\ud834";
+
+        // Print the text to console and pass-through the text from Rust back to JS.
+        // Passing through the text will "destroy" the unpaired surrogate.
+        let newText = we.writeToConsole("Original: " + text);
+
+        // It is fine to "fix" the unpaired surrogate based on the JS string.
+        // Fixing it based on the Rust string will not work because unpaired surrogate
+        // will have been "destroyed".
+        text += "\udd1e";
+        newText += "\udd1e";
+        we.writeToConsole("Fixed (JS): " + text);
+        we.writeToConsole("\"Fixed\" (Rust): " + newText);
+
+        // For more information about handling of unpaired surrogates read
+        // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/str.html#utf-16-vs-utf-8
+    });
+
+    $('#exportedType').on('click', () => {
+        let person: we.Person, p: we.Person;
+        try {
+            // Create person using constructor function.
+            // Note that person lives in "WASM land".
+            person = we.Person.new('JS', 'Foo', 42);
+
+            // Call method. Method takes ownership of person and will
+            // therefore free the associated memory.
+            p = we.fixAge(person, 2);
+            console.log(`${p.first_name}, ${p.last_name}, ${p.age}`);
+        } catch (ex) {
+            console.error(ex);
+        } finally {
+            // Free person returned by fixAge.
+            if (p) p.free();
+        }
+    });
+
+    $('#jsValue').on('click', () => {
+        try {
+            // Tip: Try to mess up person object and see error handling in action
+            const p = we.fixAgeDynamic({ firstName: 'Foo', lastName: 'Bar', age: 42}, 2);
+            console.log(p);
+        } catch (ex) {
+            console.error(ex);
+        }
+    });
+
+    $('#serdeWasm').on('click', () => {
+        try {
+            // Tip: Try to mess up person object and see error handling in action
+            const p = we.fixAgeSerdeWasm({ firstName: 'Foo', lastName: 'Bar', age: 42}, 2);
+            console.log(p);
+        } catch (ex) {
+            console.error(ex);
+        }
+    });
+
+    // Create a new display object
+    const display = we.Display.new(30);
+
+    // Get shared buffer and access it via Uint8Array
+    const pixel =  new Uint8Array(memory.buffer, display.pixel(), 30);
+
+    // Regularly redraw canvas
+    const canvas = $('#canvas')[0] as HTMLCanvasElement;
+    const ctx = canvas.getContext('2d', { alpha: false });
+    setInterval(() => {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        for (let i = 0; i < pixel.length; i++) {
+            if (pixel[i] > 0) {
+                // Intensity of RED depends on value in shared buffer
+                ctx.fillStyle = `hsl(0, 100%, ${100 - 10 * pixel[i]}%)`;
+                ctx.fillRect(i * 10, 0, 10, 10);
+            }
+        }
+
+        display.next();
+    }, 50);
+});

--- a/examples/110-wasm/www/src/index.ts
+++ b/examples/110-wasm/www/src/index.ts
@@ -8,13 +8,16 @@ $(() => {
     // Initialize our WASM package
     we.run();
 
+    //#region Importing/exporting functions from JS/Rust
     // Call functions exported from Rust
     $('#sayHello').on('click', () => we.sayHello());
     
     // Define a global function that will be called by Rust
     (<any>window).myAlert = (msg: string) => alert(msg);
     $('#sayHelloWithMyAlert').on('click', () => we.sayHelloWithMyAlert());
+    //#endregion
 
+    //#region Handle parameters
     // Demonstrate working with numbers
     $('#workWithNumbers').on('click', () => {
         console.log(`The result is ${we.workWithNumbers(0x1ffffffffffffd, 1, 1).toString(16)}`);
@@ -22,7 +25,9 @@ $(() => {
     });
 
     $('#bools').on('click', () => alert((we.allTrue(true, true) ? "" : "NOT ") + "all are true"));
+    //#endregion
 
+    //#region Panic
     $('#panic').on('click', () => {
         try {
             we.panic();
@@ -30,13 +35,17 @@ $(() => {
             console.error(ex);
         }
     });
+    //#endregion
 
+    //#region Number slices
     $('#fib').on('click', () => {
         const buffer = new Int32Array(10);
         we.fillWithFibonacci(buffer);
         $('#fibResult').text(buffer.join(','));
     });
+    //#endregion
 
+    //#region Strings
     $('#strings').on('click', () => {
         // Note that the following text contains a paired surrogate char (\ud834\udd1e = 𝄞).
         // It also contains an unpaired surrogate char (\ud834). This is fine in JavaScript.
@@ -58,7 +67,9 @@ $(() => {
         // For more information about handling of unpaired surrogates read
         // https://rustwasm.github.io/docs/wasm-bindgen/reference/types/str.html#utf-16-vs-utf-8
     });
+    //#endregion
 
+    //#region Exported Types
     $('#exportedType').on('click', () => {
         let person: we.Person, p: we.Person;
         try {
@@ -77,7 +88,9 @@ $(() => {
             if (p) p.free();
         }
     });
+    //#endregion
 
+    //#region Working with JsValue
     $('#jsValue').on('click', () => {
         try {
             // Tip: Try to mess up person object and see error handling in action
@@ -87,7 +100,9 @@ $(() => {
             console.error(ex);
         }
     });
+    //#endregion
 
+    //#region Working with serde_wasm_bindgen
     $('#serdeWasm').on('click', () => {
         try {
             // Tip: Try to mess up person object and see error handling in action
@@ -97,7 +112,9 @@ $(() => {
             console.error(ex);
         }
     });
+    //#endregion
 
+    //#region Working with shared buffers
     // Create a new display object
     const display = we.Display.new(30);
 
@@ -119,4 +136,5 @@ $(() => {
 
         display.next();
     }, 50);
+    //#endregion
 });

--- a/examples/110-wasm/www/tsconfig.json
+++ b/examples/110-wasm/www/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": false,
+    "moduleResolution": "node"
+  }
+}

--- a/examples/110-wasm/www/webpack.config.js
+++ b/examples/110-wasm/www/webpack.config.js
@@ -1,0 +1,35 @@
+const HTMLWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+
+module.exports = {
+  entry: "./src/bootstrap.ts",
+  experiments: {
+    syncWebAssembly: true
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.css$/i,
+        use: ["style-loader", "css-loader"],
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "bundle.js",
+  },
+  mode: "development",
+  plugins: [
+    new HTMLWebpackPlugin({
+      template: path.resolve(__dirname, 'src/index.html'),
+    }),
+  ]
+};


### PR DESCRIPTION
Add a WASM example demonstrating different approaches for communicating between TypeScript and Rust WASM. The example consists of many small demos that can be presented step-by-step during workshops and trainings. The code contains lots of deep links into the corresponding docs chapters.